### PR TITLE
Fix typo in English language string

### DIFF
--- a/lang/en/block_taggedcoursesearch.php
+++ b/lang/en/block_taggedcoursesearch.php
@@ -30,6 +30,6 @@ $string['nocourses'] = 'No courses';
 $string['pluginname'] = 'Tagged Course Search';
 $string['privacy:metadata'] = 'The Tagged Course search block only shows data stored in other locations.';
 $string['search_form:tags:label'] = "Tags";
-$string['user_preference:error:toolong'] = "Filter to complex to be saved.";
+$string['user_preference:error:toolong'] = "Filter too complex to be saved.";
 $string['tags'] = "Tags";
 $string['privacy:metadata:filter_criteria'] = 'This stores the last search done by the user on the Tagged Course Search block.';


### PR DESCRIPTION
Please fix typo in English language string"Filter too complex to be saved.".